### PR TITLE
TypeError: list indices must be integers or slices, not str - simple fix...

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ def download_files_from_playlist(m3u8list):
 
     segment_map_absolute_url = None
     if m3u8list.segment_map:
-        segment_map_absolute_url = urlparse.urljoin(m3u8list.base_uri, m3u8list.segment_map["uri"])
+        segment_map_absolute_url = urlparse.urljoin(m3u8list.base_uri, m3u8list.segment_map[0].uri)
     if segment_map_absolute_url:
         DOWNLOADER.download_one_file(segment_map_absolute_url)
 


### PR DESCRIPTION
When trying to use hls-downloader, I was getting the following errors:
  
File "c:\Projects\hls-downloader-master\hls-downloader-master\main.py", line 59, in download_files_from_playlist
    segment_map_absolute_url = urlparse.urljoin(m3u8list.base_uri, m3u8list.segment_map["uri"])
TypeError: list indices must be integers or slices, not str

Have not looked into the root cause too much, but debugging led me to identify segment_map as being a single item list which contains the uri key. Updating the code to pull the value for "uri" from this location seems to resolve the issue... not sure if hardcoding the index value to 0 is a good idea though...